### PR TITLE
Adjust Helm Chart Release Workflow to changed Helm Repo process

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -33,27 +33,3 @@ jobs:
         uses: helm/chart-releaser-action@v1.4.1
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
-  dispatch_helm_repo_update:
-    needs: release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get token
-        id: get_workflow_token
-        uses: peter-murray/workflow-application-token-action@v2
-        with:
-          application_id: ${{ secrets.ORG_REPO_DISPATCH_APPID }}
-          application_private_key: ${{ secrets.ORG_REPO_DISPATCH_KEY }}
-
-      - name: Trigger workflow
-        id: call_action
-        env:
-          TOKEN: ${{ steps.get_workflow_token.outputs.token }}
-        run: |
-          curl -v \
-            --request POST \
-            --url https://api.github.com/repos/catenax-ng/catenax-ng.github.io/actions/workflows/helm-build-repo-index.yaml/dispatches \
-            --header "authorization: Bearer $TOKEN" \
-            --header "Accept: application/vnd.github.v3+json" \
-            --data '{"ref":"main", "inputs": { "github_repo":"${{ github.repository }}" }}' \
-            --fail

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -25,9 +25,9 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
-          version: v3.10.0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.4.1


### PR DESCRIPTION
Removed the workflow dispatch process to trigger GH workflow to build Helm repository. Helm Repository creation will use pull instead of push process as well as different location for the Helm repo itself. So this is a restore PR.