### PR TITLE
chore!: rename helm chart name, bumping chart version

### DIFF
--- a/charts/k8s-helm-example/Chart.yaml
+++ b/charts/k8s-helm-example/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
-name: k8s-helm-example
-version: 0.1.6
+name: k8s-default-backend
+version: 1.0.0-rc1
 appVersion: "1.23.2"
 description: A Helm chart for Kubernetes for Catena-X
 home: https://github.com/catenax-ng/k8s-helm-example

--- a/charts/k8s-helm-example/values.yaml
+++ b/charts/k8s-helm-example/values.yaml
@@ -1,4 +1,4 @@
-# Default values for k8s-helm-example.
+# Default values for k8s-default-backend.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
@@ -11,8 +11,8 @@ image:
   tag: "1.23.2"
 
 imagePullSecrets: []
-nameOverride: "k8s-helm-example"
-fullnameOverride: "k8s-helm-example"
+nameOverride: "k8s-default-backend"
+fullnameOverride: "k8s-default-backend"
 
 podAnnotations: {}
 
@@ -28,6 +28,7 @@ securityContext:
   runAsGroup: 3000
 
 service:
+  environment: ""
   type: ClusterIP
   port: 8080
 


### PR DESCRIPTION
BREAKING CHANGE
Helm Chart rename to reflect that it's a productive used Helm Chart and not just an example. Chart version changed to 1.0.0-rc1