### PR TITLE
fix: change helm lint test workflow trigger

### DIFF
--- a/.github/workflows/helm-lint-and-test.yaml
+++ b/.github/workflows/helm-lint-and-test.yaml
@@ -1,6 +1,9 @@
 name: Lint and Test Charts
 
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - 'charts/**'
 
 jobs:
   lint-test:

--- a/.github/workflows/helm-lint-and-test.yaml
+++ b/.github/workflows/helm-lint-and-test.yaml
@@ -15,16 +15,16 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
-          version: v3.9.3
+          version: v3.10.3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.2.1
+        uses: helm/chart-testing-action@v2.3.1
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -38,7 +38,7 @@ jobs:
         run: ct lint --target-branch ${{ github.event.repository.default_branch }} --config charts/chart-testing-config.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@v1.4.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)


### PR DESCRIPTION
It was triggering on push to main branch. Now it will trigger on pull requests when the charts/ dir changed.