### PR TITLE
chore: dynamically add helm dependency repos

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -31,6 +31,12 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Add repositories
+        run: |
+          for dir in $(ls -d charts/*/); do
+            helm dependency list $dir 2> /dev/null | tail +2 | head -n -1 | awk '{ print "helm repo add " $1 " " $3 }' | while read cmd; do $cmd; done
+          done
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.4.1
         env:


### PR DESCRIPTION
This is a dynamic way to add dependency repositories. Also `helm dependency update` and `build` are not required as it is executed within the chart-releaser-action.

If this is merged, I'll also add this example to the proper [TRG](https://eclipse-tractusx.github.io/docs/release/trg-6/trg-6-1#implementation).